### PR TITLE
Mbasanta patch 1

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -178,11 +178,7 @@ BespokepluginGenerator.prototype.setupPackageJson = function setupPackageJson() 
     'engines': {
       'node': '>=0.10.0'
     },
-    'licenses': [
-      {
-        'type': 'MIT'
-      }
-    ],
+    'licenses': 'MIT',
     'keywords': [
       'bespoke-plugin'
     ]

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -64,8 +64,7 @@ gulp.task('compile', ['clean'], function() {
       ' * <%%= name %> v<%%= version %>',
       ' *',
       ' * Copyright <%%= new Date().getFullYear() %>, <%%= author.name %>',
-      ' * This content is released under the <%%= licenses[0].type %> license',
-      ' * <%%= licenses[0].url %>',
+      ' * This content is released under the <%%= license %> license',
       ' */\n\n'
     ].join('\n'), pkg)))
     .pipe(gulp.dest('dist'))
@@ -74,7 +73,7 @@ gulp.task('compile', ['clean'], function() {
     .pipe(header(template([
       '/*! <%%= name %> v<%%= version %> ',
       '© <%%= new Date().getFullYear() %> <%%= author.name %>, ',
-      '<%%= licenses[0].type %> License */\n'
+      '<%%= license %> License */\n'
     ].join(''), pkg)))
     .pipe(gulp.dest('dist'));
 });


### PR DESCRIPTION
The license spec for package.json has been updated.

[https://docs.npmjs.com/files/package.json#license](https://docs.npmjs.com/files/package.json#license)

This PR updates the package.json file that is created and updates the gulpfile to reference data from the newly formatted package.json.

I did **not** update the package.json for the generator.
